### PR TITLE
Enable hotspot from settings

### DIFF
--- a/share_app/src/main/AndroidManifest.xml
+++ b/share_app/src/main/AndroidManifest.xml
@@ -25,7 +25,6 @@
         </activity>
 
         <activity android:name=".activities.WifiActivity"/>
-
         <activity android:name=".activities.InstancesList"/>
 
         <activity android:name=".preferences.SettingsPreference"/>

--- a/share_app/src/main/java/org/odk/share/activities/MainActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/MainActivity.java
@@ -1,6 +1,7 @@
 package org.odk.share.activities;
 
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -10,6 +11,7 @@ import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
 
@@ -31,6 +33,8 @@ public class MainActivity extends AppCompatActivity {
 
     private boolean isHotspotRunning;
     private LocalBroadcastManager localBroadcastManager;
+    private WifiHotspotHelper wifiHotspot;
+    private boolean openSettings;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -41,7 +45,33 @@ public class MainActivity extends AppCompatActivity {
         setTitle(getString(R.string.send_forms));
         setSupportActionBar(toolbar);
 
+        wifiHotspot = WifiHotspotHelper.getInstance(this);
         isHotspotRunning = false;
+        openSettings = false;
+
+        startHotspot = (Button) findViewById(R.id.bStartHotspot);
+
+        if (wifiHotspot.isHotspotEnabled()) {
+            wifiHotspot.disableHotspot();
+        }
+
+        startHotspot.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                boolean isMobileDataEnable = WifiHotspotHelper.isMobileDataEnabled(getApplicationContext());
+                if (isMobileDataEnable) {
+                    // ask user
+                    Toast.makeText(getApplicationContext(), "Your mobile data can be consumed. Disable it and then try again",
+                            Toast.LENGTH_LONG).show();
+                } else {
+                    if (!isHotspotRunning) {
+                        initiateHotspot();
+                    } else {
+                        Toast.makeText(MainActivity.this, "Hotspot already running", Toast.LENGTH_LONG).show();
+                    }
+                }
+            }
+        });
         localBroadcastManager = LocalBroadcastManager.getInstance(this);
     }
 
@@ -74,37 +104,65 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void initiateHotspot() {
-        Intent serviceIntent = new Intent(getApplicationContext(), HotspotService.class);
-        serviceIntent.setAction(HotspotService.ACTION_START);
-        startService(serviceIntent);
 
-        Intent intent = new Intent(getApplicationContext(), HotspotService.class);
-        intent.setAction(HotspotService.ACTION_STATUS);
-        startService(intent);
-        isHotspotRunning = true;
+        // In devices having Android >= 7, created hotspot having some issues with connecting to other devices.
+        // Open settings to trigger the hotspot manually.
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            wifiHotspot.saveLastConfig();
+            wifiHotspot.setWifiConfig(wifiHotspot.createNewConfig(WifiHotspotHelper.ssid +
+                    getString(R.string.hotspot_name_suffix)));
+            final Intent intent = new Intent(Intent.ACTION_MAIN, null);
+            intent.addCategory(Intent.CATEGORY_LAUNCHER);
+            final ComponentName cn = new ComponentName("com.android.settings", "com.android.settings.TetherSettings");
+            intent.setComponent(cn);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            startActivity(intent);
+            openSettings = true;
+        } else {
+            wifiHotspot.enableHotspot();
+            Intent serviceIntent = new Intent(getApplicationContext(), HotspotService.class);
+            serviceIntent.setAction(HotspotService.ACTION_START);
+            startService(serviceIntent);
+
+            Intent intent = new Intent(getApplicationContext(), HotspotService.class);
+            intent.setAction(HotspotService.ACTION_STATUS);
+            startService(intent);
+        }
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        localBroadcastManager.registerReceiver(broadcastReceiver, new IntentFilter(HotspotService.BROADCAST_HOTSPOT_DISABLED));
+        if (openSettings) {
+            openSettings = false;
+            Intent serviceIntent = new Intent(getApplicationContext(), HotspotService.class);
+            serviceIntent.setAction(HotspotService.ACTION_START);
+            startService(serviceIntent);
+
+            Intent intent = new Intent(getApplicationContext(), HotspotService.class);
+            intent.setAction(HotspotService.ACTION_STATUS);
+            startService(intent);
+        }
+        localBroadcastManager.registerReceiver(receiverHotspotEnabled, new IntentFilter(HotspotService.BROADCAST_HOTSPOT_ENABLED));
+        localBroadcastManager.registerReceiver(receiverHotspotDisabled, new IntentFilter(HotspotService.BROADCAST_HOTSPOT_DISABLED));
     }
 
     @Override
     protected void onPause() {
         super.onPause();
-        localBroadcastManager.unregisterReceiver(broadcastReceiver);
+        localBroadcastManager.unregisterReceiver(receiverHotspotDisabled);
+        localBroadcastManager.unregisterReceiver(receiverHotspotEnabled);
     }
 
     @Override
     protected void onDestroy() {
         if (isHotspotRunning) {
-            new WifiHotspotHelper(this).disableHotspot();
+            wifiHotspot.disableHotspot();
         }
         super.onDestroy();
     }
 
-    private final BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+    private final BroadcastReceiver receiverHotspotDisabled = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
             if (intent.getAction().equals(HotspotService.BROADCAST_HOTSPOT_DISABLED)) {
@@ -128,4 +186,14 @@ public class MainActivity extends AppCompatActivity {
         }
         return super.onOptionsItemSelected(item);
     }
+
+    private final BroadcastReceiver receiverHotspotEnabled = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (intent.getAction().equals(HotspotService.BROADCAST_HOTSPOT_ENABLED)) {
+                isHotspotRunning = true;
+            }
+        }
+    };
+
 }

--- a/share_app/src/main/java/org/odk/share/activities/MainActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/MainActivity.java
@@ -3,9 +3,11 @@ package org.odk.share.activities;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.support.v4.content.LocalBroadcastManager;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
@@ -108,16 +110,7 @@ public class MainActivity extends AppCompatActivity {
         // In devices having Android >= 7, created hotspot having some issues with connecting to other devices.
         // Open settings to trigger the hotspot manually.
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-            wifiHotspot.saveLastConfig();
-            wifiHotspot.setWifiConfig(wifiHotspot.createNewConfig(WifiHotspotHelper.ssid +
-                    getString(R.string.hotspot_name_suffix)));
-            final Intent intent = new Intent(Intent.ACTION_MAIN, null);
-            intent.addCategory(Intent.CATEGORY_LAUNCHER);
-            final ComponentName cn = new ComponentName("com.android.settings", "com.android.settings.TetherSettings");
-            intent.setComponent(cn);
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
-            openSettings = true;
+            showAlertDialog();
         } else {
             wifiHotspot.enableHotspot();
             Intent serviceIntent = new Intent(getApplicationContext(), HotspotService.class);
@@ -128,6 +121,35 @@ public class MainActivity extends AppCompatActivity {
             intent.setAction(HotspotService.ACTION_STATUS);
             startService(intent);
         }
+    }
+
+    private void showAlertDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setMessage(R.string.hotspot_settings_dialog);
+        builder.setPositiveButton(getString(R.string.settings), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                wifiHotspot.saveLastConfig();
+                wifiHotspot.setWifiConfig(wifiHotspot.createNewConfig(WifiHotspotHelper.ssid +
+                        getString(R.string.hotspot_name_suffix)));
+                final Intent intent = new Intent(Intent.ACTION_MAIN, null);
+                intent.addCategory(Intent.CATEGORY_LAUNCHER);
+                final ComponentName cn = new ComponentName("com.android.settings", "com.android.settings.TetherSettings");
+                intent.setComponent(cn);
+                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(intent);
+                openSettings = true;
+            }
+        });
+        builder.setNegativeButton(getString(R.string.cancel), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+            }
+        });
+
+        builder.setCancelable(false);
+        builder.show();
     }
 
     @Override

--- a/share_app/src/main/java/org/odk/share/controller/WifiHotspotHelper.java
+++ b/share_app/src/main/java/org/odk/share/controller/WifiHotspotHelper.java
@@ -26,11 +26,11 @@ public class WifiHotspotHelper {
     private WifiManager wifiManager;
     private WifiConfiguration lastConfig;
     private WifiConfiguration currConfig;
-    private Context context;
-    private static final String ssid = "hotspot";
+    public static final String ssid = "ODK-Share";
 
-    public WifiHotspotHelper(Context context) {
-        this.context = context;
+    public static WifiHotspotHelper wifiHotspotHelper;
+
+    private WifiHotspotHelper(Context context) {
         wifiManager = (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
         for (Method method : wifiManager.getClass().getMethods()) {
             switch (method.getName()) {
@@ -50,6 +50,13 @@ public class WifiHotspotHelper {
                     setWifiApConfig = method;
             }
         }
+    }
+
+    public static synchronized WifiHotspotHelper getInstance(Context context) {
+        if (wifiHotspotHelper == null) {
+            wifiHotspotHelper = new WifiHotspotHelper(context);
+        }
+        return wifiHotspotHelper;
     }
 
     public boolean isSupported() {
@@ -102,9 +109,12 @@ public class WifiHotspotHelper {
         return null;
     }
 
-    public boolean enableHotspot() {
-        // Save last wifi Configuration
+    public void saveLastConfig() {
         lastConfig = getWifiConfig();
+    }
+
+    public boolean enableHotspot() {
+        saveLastConfig();
 
         currConfig = createNewConfig(ssid + context.getString(R.string.hotspot_name_suffix));
         return toggleHotspot(currConfig, true);
@@ -112,7 +122,7 @@ public class WifiHotspotHelper {
 
     public boolean disableHotspot() {
         setWifiConfig(lastConfig);
-        return toggleHotspot(currConfig, false);
+        return toggleHotspot(lastConfig, false);
     }
 
     private boolean toggleHotspot(WifiConfiguration configuration, boolean enable) {
@@ -129,7 +139,7 @@ public class WifiHotspotHelper {
         return false;
     }
 
-    private WifiConfiguration createNewConfig(String ssid) {
+    public WifiConfiguration createNewConfig(String ssid) {
         WifiConfiguration wifiConf = new WifiConfiguration();
         wifiConf.SSID = ssid;
         wifiConf.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.NONE);

--- a/share_app/src/main/java/org/odk/share/controller/WifiHotspotHelper.java
+++ b/share_app/src/main/java/org/odk/share/controller/WifiHotspotHelper.java
@@ -26,11 +26,13 @@ public class WifiHotspotHelper {
     private WifiManager wifiManager;
     private WifiConfiguration lastConfig;
     private WifiConfiguration currConfig;
+    private Context context;
     public static final String ssid = "ODK-Share";
 
     public static WifiHotspotHelper wifiHotspotHelper;
 
     private WifiHotspotHelper(Context context) {
+        this.context = context;
         wifiManager = (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
         for (Method method : wifiManager.getClass().getMethods()) {
             switch (method.getName()) {

--- a/share_app/src/main/res/values/strings.xml
+++ b/share_app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="hotspot_start">Starting hotspot</string>
     <string name="stop">Stop</string>
     <string name="start_hotspot">Start Hotspot</string>
+    <string name="hotspot_settings_dialog">Enable protable hotspot from the settings.</string>
     <string name="hotspot_name_suffix">-odk-share</string>
     <string name="hotspot_already_running">Hotspot already running</string>
     <string name="mobile_data_message">Your mobile data can be consumed. Disable it and then try again</string>


### PR DESCRIPTION
Closes #19 

Devices with android version >= 7 is able to create and enable hotspot network from the app but no other devices are able to connect to it.
To fix this issue, a check is added so that user can navigate to hotspot settings and then have to enable from their, then only other devices will be able to connect to it.