### PR TITLE
Hotspot connection issue resolved for devices >= Oreo

### DIFF
--- a/share_app/src/main/AndroidManifest.xml
+++ b/share_app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+    <!-- Device with versions >= Oreo need location permission to start/stop the hotspot-->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 

--- a/share_app/src/main/AndroidManifest.xml
+++ b/share_app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
     <application
         android:name=".application.Share"

--- a/share_app/src/main/java/org/odk/share/activities/WifiActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/WifiActivity.java
@@ -189,7 +189,10 @@ public class WifiActivity extends InjectableActivity {
 
     private void onListItemClick(View view, int i) {
         Timber.d("Clicked %s", scanResultList.get(i));
-        if (WifiHelper.isClose(scanResultList.get(i))) {
+
+        if (scanResultList.get(i).SSID.contains(getString(R.string.hotspot_name_prefix_oreo))) {
+          Toast.makeText(this, getString(R.string.scan_alert_oreo), Toast.LENGTH_LONG).show();
+        } else if (WifiHelper.isClose(scanResultList.get(i))) {
             // Show dialog and ask for password
             showPasswordDialog(scanResultList.get(i));
         } else {
@@ -314,7 +317,8 @@ public class WifiActivity extends InjectableActivity {
         @Override
         public void onReceive(Context c, Intent intent) {
             for (ScanResult scanResult : wifiManager.getScanResults()) {
-                if (scanResult.SSID.contains(getString(R.string.hotspot_name_suffix))) {
+                if (scanResult.SSID.contains(getString(R.string.hotspot_name_suffix)) ||
+                        scanResult.SSID.contains(getString(R.string.hotspot_name_prefix_oreo))) {
                     scanResultList.add(scanResult);
                 }
             }

--- a/share_app/src/main/res/values/strings.xml
+++ b/share_app/src/main/res/values/strings.xml
@@ -5,7 +5,9 @@
     <string name="stop">Stop</string>
     <string name="hotspot_settings_dialog">Enable portable hotspot from the settings.</string>
     <string name="hotspot_name_suffix">-odk-share</string>
+    <string name="hotspot_name_prefix_oreo">AndroidShare</string>
     <string name="hotspot_already_running">Hotspot already running</string>
+    <string name="scan_alert_oreo">Scan QR Code to connect to this network</string>
 
     <string name="saved_forms">Saved Forms</string>
     <string name="send_selected">Send</string>


### PR DESCRIPTION
Fixes #33 

[WifiManager](https://developer.android.com/reference/android/net/wifi/WifiManager#startLocalOnlyHotspot(android.net.wifi.WifiManager.LocalOnlyHotspotCallback,%20android.os.Handler))
For devices having android version >= 8 they have added public API which can be used to enable and disable the hotspot. 3rd party apps can only enable/disable it, they are not allowed to change the WifiConfiguration. 

For Oreo or greater versions, user have to scan the QR Code to connect to the network.

Useful Links- 
[https://stackoverflow.com/questions/45984345/how-to-turn-on-off-wifi-hotspot-programmatically-in-android-8-0-oreo/45996578#45996578](https://stackoverflow.com/questions/47700717/change-wifi-hotspots-ssid-and-password-in-android-oreo-8-x)
[https://stackoverflow.com/questions/45984345/how-to-turn-on-off-wifi-hotspot-programmatically-in-android-8-0-oreo/45996578#45996578](https://stackoverflow.com/questions/45984345/how-to-turn-on-off-wifi-hotspot-programmatically-in-android-8-0-oreo/45996578#45996578)