### PR TITLE
Dialog added before hotspot is stopped

### DIFF
--- a/share_app/src/main/AndroidManifest.xml
+++ b/share_app/src/main/AndroidManifest.xml
@@ -36,9 +36,11 @@
         <activity android:name=".activities.WifiActivity" />
         <activity android:name=".activities.InstancesList" />
         <activity android:name=".preferences.SettingsPreference" />
-        <activity android:name=".activities.SendActivity" />
         <activity android:name=".activities.WebViewActivity"/>
         <activity android:name=".activities.AboutActivity"/>
+        <activity
+            android:name=".activities.SendActivity"
+            android:configChanges="orientation|screenSize"/>
 
         <service android:name=".services.HotspotService" />
 

--- a/share_app/src/main/java/org/odk/share/activities/SendActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/SendActivity.java
@@ -106,6 +106,11 @@ public class SendActivity extends InjectableActivity {
         }
     }
 
+    @Override
+    public void onBackPressed() {
+        stopHotspotAlertDialog();
+    }
+
     /**
      * Creates a subscription for listening to all hotspot events being send through the
      * application's {@link RxEventBus}
@@ -185,6 +190,37 @@ public class SendActivity extends InjectableActivity {
             public void onClick(DialogInterface dialog, int which) {
                 dialog.dismiss();
                 finish();
+            }
+        });
+
+        builder.setCancelable(false);
+        builder.show();
+    }
+
+    private void stopHotspotAlertDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setMessage(R.string.stop_sending);
+        builder.setPositiveButton(getString(R.string.stop), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    turnOffHotspot();
+                }
+
+                if (isHotspotRunning) {
+                    wifiHotspot.disableHotspot();
+                }
+
+                senderService.cancel();
+                Timber.d("Hotspot Stopped");
+                compositeDisposable.dispose();
+                finish();
+            }
+        });
+        builder.setNegativeButton(getString(R.string.cancel), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
             }
         });
 
@@ -286,22 +322,6 @@ public class SendActivity extends InjectableActivity {
     protected void onPause() {
         super.onPause();
         compositeDisposable.clear();
-    }
-
-    @Override
-    protected void onDestroy() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            turnOffHotspot();
-        }
-
-        if (isHotspotRunning) {
-            wifiHotspot.disableHotspot();
-        }
-
-        senderService.cancel();
-        Timber.d("Hotspot Stopped");
-        compositeDisposable.dispose();
-        super.onDestroy();
     }
 
     private void startSending() {

--- a/share_app/src/main/res/values/strings.xml
+++ b/share_app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="connecting_wifi">Connecting to wifi</string>
     <string name="ok">OK</string>
     <string name="canceled">Canceled</string>
+    <string name="stop_sending">Stop Sending</string>
 
 
     <string name="sending_items">Sending %1$s of %2$s form(s)</string>


### PR DESCRIPTION
Closes #72 

Screen orientation issue resolved and added a dialog before turning the hotspot off so that user can know that leaving the activity may stop the connection.

For future, we can have an option to run the hotspot connection throughout the activities.