### PR TITLE
Added UUID to forms so that forms can be identified uniquely

### DIFF
--- a/share_app/src/main/AndroidManifest.xml
+++ b/share_app/src/main/AndroidManifest.xml
@@ -48,12 +48,15 @@
             android:stateNotNeeded="true"
             tools:replace="android:screenOrientation" />
         <activity android:name=".activities.InstanceManagerTabs" />
+        <activity android:name=".activities.ReviewFormActivity" />
 
         <provider
             android:name=".provider.TransferProvider"
             android:authorities="org.odk.share.provider.odk.instances" />
 
-        <activity android:name=".activities.ReviewFormActivity" />
+        <provider
+            android:name=".provider.InstanceMapProvider"
+            android:authorities="org.odk.share.provider.odk.map" />
     </application>
 
 </manifest>

--- a/share_app/src/main/java/org/odk/share/activities/InstancesList.java
+++ b/share_app/src/main/java/org/odk/share/activities/InstancesList.java
@@ -17,6 +17,7 @@ import org.odk.share.R;
 import org.odk.share.adapters.InstanceAdapter;
 import org.odk.share.dao.InstancesDao;
 import org.odk.share.provider.InstanceProviderAPI;
+import org.odk.share.utilities.ApplicationConstants;
 import org.odk.share.utilities.ArrayUtils;
 
 import java.util.LinkedHashSet;
@@ -24,6 +25,8 @@ import java.util.LinkedHashSet;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+
+import static org.odk.share.fragments.ReviewedInstancesFragment.MODE;
 
 public class InstancesList extends InstanceListActivity implements LoaderManager.LoaderCallbacks<Cursor> {
 
@@ -112,7 +115,7 @@ public class InstancesList extends InstanceListActivity implements LoaderManager
         Long[] arr = selectedInstances.toArray(new Long[selectedInstances.size()]);
         long[] a = ArrayUtils.toPrimitive(arr);
         intent.putExtra(INSTANCE_IDS, a);
-        intent.putExtra("mode", 1);
+        intent.putExtra(MODE, ApplicationConstants.ASK_REVIEW_MODE);
         startActivity(intent);
         finish();
     }

--- a/share_app/src/main/java/org/odk/share/activities/InstancesList.java
+++ b/share_app/src/main/java/org/odk/share/activities/InstancesList.java
@@ -112,6 +112,7 @@ public class InstancesList extends InstanceListActivity implements LoaderManager
         Long[] arr = selectedInstances.toArray(new Long[selectedInstances.size()]);
         long[] a = ArrayUtils.toPrimitive(arr);
         intent.putExtra(INSTANCE_IDS, a);
+        intent.putExtra("mode", 1);
         startActivity(intent);
         finish();
     }

--- a/share_app/src/main/java/org/odk/share/activities/MainActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/MainActivity.java
@@ -1,5 +1,6 @@
 package org.odk.share.activities;
 
+import android.content.ContentValues;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
@@ -18,12 +19,20 @@ import org.odk.share.R;
 import org.odk.share.adapters.FormsAdapter;
 import org.odk.share.application.Share;
 import org.odk.share.dao.FormsDao;
+import org.odk.share.dao.InstanceMapDao;
+import org.odk.share.database.ShareDatabaseHelper;
 import org.odk.share.preferences.SettingsPreference;
 import org.odk.share.provider.FormsProviderAPI;
+
+import java.util.UUID;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import timber.log.Timber;
+
+import static org.odk.share.dto.InstanceMap.INSTANCE_UUID;
+import static org.odk.share.dto.TransferInstance.INSTANCE_ID;
 
 public class MainActivity extends FormListActivity implements LoaderManager.LoaderCallbacks<Cursor> {
 
@@ -55,6 +64,8 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
         setSupportActionBar(toolbar);
         Share.createODKDirs();
 
+        getSupportLoaderManager().initLoader(FORM_LOADER, null, this);
+
         LinearLayoutManager llm = new LinearLayoutManager(this);
         llm.setOrientation(LinearLayoutManager.VERTICAL);
         recyclerView.setLayoutManager(llm);
@@ -64,7 +75,7 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
     protected void onResume() {
         super.onResume();
         setupAdapter();
-        getSupportLoaderManager().initLoader(FORM_LOADER, null, this);
+        getSupportLoaderManager().restartLoader(FORM_LOADER, null, this);
     }
 
     private void setupAdapter() {

--- a/share_app/src/main/java/org/odk/share/activities/MainActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/MainActivity.java
@@ -55,8 +55,6 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
         setSupportActionBar(toolbar);
         Share.createODKDirs();
 
-        getSupportLoaderManager().initLoader(FORM_LOADER, null, this);
-
         LinearLayoutManager llm = new LinearLayoutManager(this);
         llm.setOrientation(LinearLayoutManager.VERTICAL);
         recyclerView.setLayoutManager(llm);
@@ -66,7 +64,7 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
     protected void onResume() {
         super.onResume();
         setupAdapter();
-        getSupportLoaderManager().restartLoader(FORM_LOADER, null, this);
+        getSupportLoaderManager().initLoader(FORM_LOADER, null, this);
     }
 
     private void setupAdapter() {

--- a/share_app/src/main/java/org/odk/share/activities/MainActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/MainActivity.java
@@ -1,6 +1,5 @@
 package org.odk.share.activities;
 
-import android.content.ContentValues;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
@@ -19,20 +18,12 @@ import org.odk.share.R;
 import org.odk.share.adapters.FormsAdapter;
 import org.odk.share.application.Share;
 import org.odk.share.dao.FormsDao;
-import org.odk.share.dao.InstanceMapDao;
-import org.odk.share.database.ShareDatabaseHelper;
 import org.odk.share.preferences.SettingsPreference;
 import org.odk.share.provider.FormsProviderAPI;
-
-import java.util.UUID;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import timber.log.Timber;
-
-import static org.odk.share.dto.InstanceMap.INSTANCE_UUID;
-import static org.odk.share.dto.TransferInstance.INSTANCE_ID;
 
 public class MainActivity extends FormListActivity implements LoaderManager.LoaderCallbacks<Cursor> {
 

--- a/share_app/src/main/java/org/odk/share/activities/ReviewFormActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/ReviewFormActivity.java
@@ -129,10 +129,10 @@ public class ReviewFormActivity extends AppCompatActivity {
 
     @OnClick(R.id.bReject)
     public void rejectForm() {
-        String feedback = description.getText().toString();
+        String feedbackText = feedback.getText().toString();
         if (feedback != null) {
             ContentValues values = new ContentValues();
-            values.put(TransferInstance.INSTRUCTIONS, feedback);
+            values.put(TransferInstance.INSTRUCTIONS, feedbackText);
             values.put(TransferInstance.REVIEW_STATUS, TransferInstance.STATUS_REJECTED);
             Long now = System.currentTimeMillis();
             values.put(LAST_STATUS_CHANGE_DATE, now);

--- a/share_app/src/main/java/org/odk/share/activities/SendActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/SendActivity.java
@@ -39,6 +39,8 @@ import timber.log.Timber;
 
 import static android.view.View.VISIBLE;
 import static org.odk.share.activities.InstancesList.INSTANCE_IDS;
+import static org.odk.share.fragments.ReviewedInstancesFragment.MODE;
+import static org.odk.share.utilities.ApplicationConstants.ASK_REVIEW_MODE;
 
 /**
  * Created by laksh on 6/9/2018.
@@ -90,7 +92,7 @@ public class SendActivity extends InjectableActivity {
         setSupportActionBar(toolbar);
 
         instancesIds = getIntent().getLongArrayExtra(INSTANCE_IDS);
-        mode = getIntent().getIntExtra("mode", 1);
+        mode = getIntent().getIntExtra(MODE, ASK_REVIEW_MODE);
 
         port = SocketUtils.getPort();
 

--- a/share_app/src/main/java/org/odk/share/activities/SendActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/SendActivity.java
@@ -75,6 +75,7 @@ public class SendActivity extends InjectableActivity {
     private String alertMsg;
     private int port;
     private long[] instancesIds;
+    private int mode;
 
     private WifiManager.LocalOnlyHotspotReservation hotspotReservation;
     private WifiConfiguration currentConfig;
@@ -89,6 +90,7 @@ public class SendActivity extends InjectableActivity {
         setSupportActionBar(toolbar);
 
         instancesIds = getIntent().getLongArrayExtra(INSTANCE_IDS);
+        mode = getIntent().getIntExtra("mode",1);
 
         port = SocketUtils.getPort();
 
@@ -305,7 +307,7 @@ public class SendActivity extends InjectableActivity {
     }
 
     private void startSending() {
-        senderService.startUploading(instancesIds, port);
+        senderService.startUploading(instancesIds, port, mode);
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)

--- a/share_app/src/main/java/org/odk/share/activities/SendActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/SendActivity.java
@@ -90,7 +90,7 @@ public class SendActivity extends InjectableActivity {
         setSupportActionBar(toolbar);
 
         instancesIds = getIntent().getLongArrayExtra(INSTANCE_IDS);
-        mode = getIntent().getIntExtra("mode",1);
+        mode = getIntent().getIntExtra("mode", 1);
 
         port = SocketUtils.getPort();
 
@@ -239,7 +239,7 @@ public class SendActivity extends InjectableActivity {
                         case FINISHED:
                             hideDialog(PROGRESS_DIALOG);
                             String result = uploadEvent.getResult();
-                            createAlertDialog(getString(R.string.transfer_result), getString(R.string.send_success, result));
+                            createAlertDialog(getString(R.string.transfer_result), result);
                             break;
                         case ERROR:
                             hideDialog(PROGRESS_DIALOG);

--- a/share_app/src/main/java/org/odk/share/activities/WifiActivity.java
+++ b/share_app/src/main/java/org/odk/share/activities/WifiActivity.java
@@ -168,7 +168,7 @@ public class WifiActivity extends InjectableActivity {
                         case FINISHED:
                             dismissDialog(DIALOG_DOWNLOAD_PROGRESS);
                             String result = downloadEvent.getResult();
-                            createAlertDialog(getString(R.string.transfer_result), getString(R.string.receive_success, result));
+                            createAlertDialog(getString(R.string.transfer_result), result);
                             break;
                         case ERROR:
                             dismissDialog(DIALOG_DOWNLOAD_PROGRESS);

--- a/share_app/src/main/java/org/odk/share/adapters/TransferInstanceAdapter.java
+++ b/share_app/src/main/java/org/odk/share/adapters/TransferInstanceAdapter.java
@@ -87,7 +87,27 @@ public class TransferInstanceAdapter extends RecyclerView.Adapter<TransferInstan
         String statusChangeTime = dateFormat.format(date);
 
         if (instance.getTransferStatus().equalsIgnoreCase(context.getString(R.string.sent))) {
-            holder.subtitle.setText(context.getString(R.string.sent_on, statusChangeTime));
+            if (instance.getReceivedReviewStatus() == TransferInstance.STATUS_ACCEPTED) {
+                StringBuilder sb = new StringBuilder();
+                sb.append(context.getString(R.string.form_received_by_reviewer, context.getString(R.string.accepted)));
+                if (instance.getInstructions() != null && instance.getInstructions().length() > 0) {
+                    sb.append(context.getString(R.string.feedback_sent, instance.getInstructions()));
+                } else {
+                    sb.append(context.getString(R.string.no_feedback_sent));
+                }
+                holder.subtitle.setText(sb.toString());
+            } else if (instance.getReceivedReviewStatus() == TransferInstance.STATUS_REJECTED) {
+                StringBuilder sb = new StringBuilder();
+                sb.append(context.getString(R.string.form_received_by_reviewer, context.getString(R.string.rejected)));
+                if (instance.getInstructions() != null && instance.getInstructions().length() > 0) {
+                    sb.append(context.getString(R.string.feedback_sent, instance.getInstructions()));
+                } else {
+                    sb.append(context.getString(R.string.no_feedback_sent));
+                }
+                holder.subtitle.setText(sb.toString());
+            } else {
+                holder.subtitle.setText(context.getString(R.string.sent_on, statusChangeTime));
+            }
         } else if (instance.getReviewed() == TransferInstance.STATUS_ACCEPTED) {
             holder.subtitle.setText(context.getString(R.string.approved_on, statusChangeTime));
         } else if (instance.getReviewed() == TransferInstance.STATUS_REJECTED) {

--- a/share_app/src/main/java/org/odk/share/adapters/TransferInstanceAdapter.java
+++ b/share_app/src/main/java/org/odk/share/adapters/TransferInstanceAdapter.java
@@ -87,18 +87,12 @@ public class TransferInstanceAdapter extends RecyclerView.Adapter<TransferInstan
         String statusChangeTime = dateFormat.format(date);
 
         if (instance.getTransferStatus().equalsIgnoreCase(context.getString(R.string.sent))) {
-            if (instance.getReceivedReviewStatus() == TransferInstance.STATUS_ACCEPTED) {
+            if (instance.getReceivedReviewStatus() == TransferInstance.STATUS_ACCEPTED ||
+                    instance.getReceivedReviewStatus() == TransferInstance.STATUS_REJECTED) {
                 StringBuilder sb = new StringBuilder();
-                sb.append(context.getString(R.string.form_received_by_reviewer, context.getString(R.string.accepted)));
-                if (instance.getInstructions() != null && instance.getInstructions().length() > 0) {
-                    sb.append(context.getString(R.string.feedback_sent, instance.getInstructions()));
-                } else {
-                    sb.append(context.getString(R.string.no_feedback_sent));
-                }
-                holder.subtitle.setText(sb.toString());
-            } else if (instance.getReceivedReviewStatus() == TransferInstance.STATUS_REJECTED) {
-                StringBuilder sb = new StringBuilder();
-                sb.append(context.getString(R.string.form_received_by_reviewer, context.getString(R.string.rejected)));
+                sb.append(context.getString(R.string.form_received_by_reviewer,
+                        instance.getReceivedReviewStatus() == TransferInstance.STATUS_ACCEPTED ?
+                                context.getString(R.string.accepted) : context.getString(R.string.rejected)));
                 if (instance.getInstructions() != null && instance.getInstructions().length() > 0) {
                     sb.append(context.getString(R.string.feedback_sent, instance.getInstructions()));
                 } else {

--- a/share_app/src/main/java/org/odk/share/application/Share.java
+++ b/share_app/src/main/java/org/odk/share/application/Share.java
@@ -29,8 +29,9 @@ public class Share extends DaggerApplication {
     }
 
     public static final String ODK_ROOT = Environment.getExternalStorageDirectory() + File.separator + "share";
-    public static final String FORMS_PATH = ODK_ROOT + File.separator + "forms";
-    public static final String INSTANCES_PATH = ODK_ROOT + File.separator + "instances";
+    public static final String ODK_COLLECT_ROOT = Environment.getExternalStorageDirectory() + File.separator + "odk";
+    public static final String FORMS_PATH = ODK_COLLECT_ROOT + File.separator + "forms";
+    public static final String INSTANCES_PATH = ODK_COLLECT_ROOT + File.separator + "instances";
     public static final String METADATA_PATH = ODK_ROOT + File.separator + "metadata";
 
     @Override

--- a/share_app/src/main/java/org/odk/share/dao/InstanceMapDao.java
+++ b/share_app/src/main/java/org/odk/share/dao/InstanceMapDao.java
@@ -1,0 +1,87 @@
+package org.odk.share.dao;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+import org.odk.share.application.Share;
+
+import java.util.HashMap;
+
+import timber.log.Timber;
+
+import static org.odk.share.dto.InstanceMap.INSTANCE_ID;
+import static org.odk.share.dto.InstanceMap.INSTANCE_UUID;
+import static org.odk.share.provider.InstanceMapProvider.CONTENT_URI;
+
+
+/**
+ * Created by laksh on 8/2/2018.
+ */
+
+public class InstanceMapDao {
+
+    public int updateInstance(ContentValues values, String where, String[] whereArgs) {
+        return Share.getInstance().getContentResolver().update(CONTENT_URI, values, where, whereArgs);
+    }
+
+    public HashMap<Long, String> getInstanceMap() {
+        Cursor cursor = getInstancesCursor(null, null, null, null);
+
+        HashMap<Long, String> instanceMap = new HashMap<>();
+        if (cursor != null) {
+            Timber.d("CUrsor "+ cursor.getCount());
+            try {
+                while (cursor.moveToNext()) {
+                    long instanceId = cursor.getLong(cursor.getColumnIndex(INSTANCE_ID));
+                    String uuid = cursor.getString(cursor.getColumnIndex(INSTANCE_UUID));
+                    instanceMap.put(instanceId, uuid);
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        return instanceMap;
+    }
+
+    public HashMap<String, Long> getInstanceUUIDMap() {
+        Cursor cursor = getInstancesCursor(null, null, null, null);
+
+        HashMap<String, Long> instanceMap = new HashMap<>();
+        if (cursor != null) {
+            try {
+                while (cursor.moveToNext()) {
+                    long instanceId = cursor.getLong(cursor.getColumnIndex(INSTANCE_ID));
+                    String uuid = cursor.getString(cursor.getColumnIndex(INSTANCE_UUID));
+                    instanceMap.put(uuid, instanceId);
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        return instanceMap;
+    }
+
+    public Cursor getInstancesCursor(String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        return Share.getInstance().getContentResolver()
+                .query(CONTENT_URI, projection, selection, selectionArgs, sortOrder);
+    }
+
+    public long getInstanceId(String uuid) {
+        String selection = INSTANCE_UUID + "=?";
+        String[] selectionArgs = {uuid};
+
+        Cursor cursor = getInstancesCursor(null, selection, selectionArgs, null);
+        long id = -1;
+
+        if (cursor != null) {
+            try {
+                if (cursor.moveToNext()) {
+                    id = cursor.getLong(cursor.getColumnIndex(INSTANCE_ID));
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        return id;
+    }
+}

--- a/share_app/src/main/java/org/odk/share/dao/InstanceMapDao.java
+++ b/share_app/src/main/java/org/odk/share/dao/InstanceMapDao.java
@@ -29,7 +29,7 @@ public class InstanceMapDao {
 
         HashMap<Long, String> instanceMap = new HashMap<>();
         if (cursor != null) {
-            Timber.d("CUrsor "+ cursor.getCount());
+            Timber.d("CUrsor " + cursor.getCount());
             try {
                 while (cursor.moveToNext()) {
                     long instanceId = cursor.getLong(cursor.getColumnIndex(INSTANCE_ID));

--- a/share_app/src/main/java/org/odk/share/dao/TransferDao.java
+++ b/share_app/src/main/java/org/odk/share/dao/TransferDao.java
@@ -2,6 +2,7 @@ package org.odk.share.dao;
 
 import android.content.ContentValues;
 import android.database.Cursor;
+import android.support.annotation.NonNull;
 import android.support.v4.content.CursorLoader;
 
 import org.odk.share.application.Share;
@@ -84,7 +85,27 @@ public class TransferDao {
         return Share.getInstance().getContentResolver().update(CONTENT_URI, values, where, whereArgs);
     }
 
+    public TransferInstance getReceivedTransferInstanceFromInstanceId(long instanceId) {
+        String selection = TransferInstance.INSTANCE_ID + " =? AND " + TransferInstance.TRANSFER_STATUS + " =?";
+        String[] selectionArgs = {String.valueOf(instanceId), TransferInstance.STATUS_FORM_RECEIVE};
+        Cursor cursor = getInstancesCursor(null, selection, selectionArgs, null);
+        List<TransferInstance> transferInstanceList = getInstancesFromCursor(cursor);
+        if (transferInstanceList.size() > 0) {
+            return transferInstanceList.get(0);
+        }
+        return null;
+    }
 
+    public TransferInstance getSentTransferInstanceFromInstanceId(long instanceId) {
+        String selection = TransferInstance.INSTANCE_ID + " =? AND " + TransferInstance.TRANSFER_STATUS + " =?";
+        String[] selectionArgs = {String.valueOf(instanceId), TransferInstance.STATUS_FORM_SENT};
+        Cursor cursor = getInstancesCursor(null, selection, selectionArgs, null);
+        List<TransferInstance> transferInstanceList = getInstancesFromCursor(cursor);
+        if (transferInstanceList.size() > 0) {
+            return transferInstanceList.get(0);
+        }
+        return null;
+    }
     public List<TransferInstance> getInstancesFromCursor(Cursor cursor) {
         List<TransferInstance> instances = new ArrayList<>();
         if (cursor != null) {

--- a/share_app/src/main/java/org/odk/share/dao/TransferDao.java
+++ b/share_app/src/main/java/org/odk/share/dao/TransferDao.java
@@ -2,7 +2,6 @@ package org.odk.share.dao;
 
 import android.content.ContentValues;
 import android.database.Cursor;
-import android.support.annotation.NonNull;
 import android.support.v4.content.CursorLoader;
 
 import org.odk.share.application.Share;
@@ -41,6 +40,12 @@ public class TransferDao {
     public Cursor getUnreviewedInstancesCursor() {
         String selection = TransferInstance.REVIEW_STATUS + " =? ";
         String[] selectionArgs = {String.valueOf(TransferInstance.STATUS_UNREVIEWED)};
+        return getInstancesCursor(null, selection, selectionArgs, null);
+    }
+
+    public Cursor getSentInstanceInstanceCursorUsingId(long id) {
+        String selection = TransferInstance.TRANSFER_STATUS + " =? AND " + TransferInstance.INSTANCE_ID + " =?";
+        String[] selectionArgs = {TransferInstance.STATUS_FORM_SENT, String.valueOf(id)};
         return getInstancesCursor(null, selection, selectionArgs, null);
     }
 
@@ -106,6 +111,7 @@ public class TransferDao {
         }
         return null;
     }
+
     public List<TransferInstance> getInstancesFromCursor(Cursor cursor) {
         List<TransferInstance> instances = new ArrayList<>();
         if (cursor != null) {
@@ -117,6 +123,7 @@ public class TransferDao {
                     int instanceIdColumnIndex = cursor.getColumnIndex(TransferInstance.INSTANCE_ID);
                     int transferStatusColumnIndex = cursor.getColumnIndex(TransferInstance.TRANSFER_STATUS);
                     int lastStatusChangeDateColumnIndex = cursor.getColumnIndex(TransferInstance.LAST_STATUS_CHANGE_DATE);
+                    int receivedReviewStatusColumnIndex = cursor.getColumnIndex(TransferInstance.RECEIVED_REVIEW_STATUS);
 
                     TransferInstance transferInstance = new TransferInstance();
                     transferInstance.setId(cursor.getLong(idColumnIndex));
@@ -125,6 +132,7 @@ public class TransferDao {
                     transferInstance.setInstanceId(cursor.getLong(instanceIdColumnIndex));
                     transferInstance.setTransferStatus(cursor.getString(transferStatusColumnIndex));
                     transferInstance.setLastStatusChangeDate(cursor.getLong(lastStatusChangeDateColumnIndex));
+                    transferInstance.setReceivedReviewStatus(cursor.getInt(receivedReviewStatusColumnIndex));
 
                     instances.add(transferInstance);
                 }

--- a/share_app/src/main/java/org/odk/share/database/ShareDatabaseHelper.java
+++ b/share_app/src/main/java/org/odk/share/database/ShareDatabaseHelper.java
@@ -9,10 +9,12 @@ import org.odk.share.application.Share;
 
 import timber.log.Timber;
 
+import static org.odk.share.dto.InstanceMap.INSTANCE_UUID;
 import static org.odk.share.dto.TransferInstance.ID;
 import static org.odk.share.dto.TransferInstance.INSTANCE_ID;
 import static org.odk.share.dto.TransferInstance.INSTRUCTIONS;
 import static org.odk.share.dto.TransferInstance.LAST_STATUS_CHANGE_DATE;
+import static org.odk.share.dto.TransferInstance.RECEIVED_REVIEW;
 import static org.odk.share.dto.TransferInstance.REVIEW_STATUS;
 import static org.odk.share.dto.TransferInstance.STATUS_UNREVIEWED;
 import static org.odk.share.dto.TransferInstance.TRANSFER_STATUS;
@@ -26,6 +28,7 @@ public class ShareDatabaseHelper extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "share.db";
     public static final String SHARE_TABLE_NAME = "transfers";
+    public static final String SHARE_INSTANCE_TABLE = "map_instance";
 
     private static final int DATABASE_VERSION = 1;
 
@@ -53,8 +56,14 @@ public class ShareDatabaseHelper extends SQLiteOpenHelper {
                 + INSTRUCTIONS + " text, "
                 + INSTANCE_ID + " integer not null, "
                 + TRANSFER_STATUS + " text not null, "
+                + RECEIVED_REVIEW + " integer,"
                 + VISITED_COUNT + " integer, "
                 + LAST_STATUS_CHANGE_DATE + " date not null ); ");
+
+        db.execSQL("CREATE TABLE " + SHARE_INSTANCE_TABLE + " ("
+                + ID + " integer primary key, "
+                + INSTANCE_UUID + " text not null, "
+                + INSTANCE_ID + " integer not null ); ");
 
     }
 
@@ -72,6 +81,15 @@ public class ShareDatabaseHelper extends SQLiteOpenHelper {
         }
         long id = sqLiteDatabase.insert(SHARE_TABLE_NAME, null, values);
         sqLiteDatabase.close();
+        return id;
+    }
+
+    public long insertMapping(ContentValues values) {
+        SQLiteDatabase sqLiteDatabase = this.getWritableDatabase();
+
+        long id = sqLiteDatabase.insert(SHARE_INSTANCE_TABLE, null, values);
+        sqLiteDatabase.close();
+
         return id;
     }
 }

--- a/share_app/src/main/java/org/odk/share/database/ShareDatabaseHelper.java
+++ b/share_app/src/main/java/org/odk/share/database/ShareDatabaseHelper.java
@@ -14,7 +14,7 @@ import static org.odk.share.dto.TransferInstance.ID;
 import static org.odk.share.dto.TransferInstance.INSTANCE_ID;
 import static org.odk.share.dto.TransferInstance.INSTRUCTIONS;
 import static org.odk.share.dto.TransferInstance.LAST_STATUS_CHANGE_DATE;
-import static org.odk.share.dto.TransferInstance.RECEIVED_REVIEW;
+import static org.odk.share.dto.TransferInstance.RECEIVED_REVIEW_STATUS;
 import static org.odk.share.dto.TransferInstance.REVIEW_STATUS;
 import static org.odk.share.dto.TransferInstance.STATUS_UNREVIEWED;
 import static org.odk.share.dto.TransferInstance.TRANSFER_STATUS;
@@ -56,7 +56,7 @@ public class ShareDatabaseHelper extends SQLiteOpenHelper {
                 + INSTRUCTIONS + " text, "
                 + INSTANCE_ID + " integer not null, "
                 + TRANSFER_STATUS + " text not null, "
-                + RECEIVED_REVIEW + " integer,"
+                + RECEIVED_REVIEW_STATUS + " integer,"
                 + VISITED_COUNT + " integer, "
                 + LAST_STATUS_CHANGE_DATE + " date not null ); ");
 

--- a/share_app/src/main/java/org/odk/share/dto/InstanceMap.java
+++ b/share_app/src/main/java/org/odk/share/dto/InstanceMap.java
@@ -1,0 +1,39 @@
+package org.odk.share.dto;
+
+/**
+ * Created by laksh on 8/2/2018.
+ */
+
+public class InstanceMap {
+    public static final String INSTANCE_UUID = "instance_uuid";
+    public static final String ID = "_id";
+    public static final String INSTANCE_ID = "instanceId";
+
+    long id;
+    String uuid;
+    long transferId;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public long getTransferId() {
+        return transferId;
+    }
+
+    public void setTransferId(long transferId) {
+        this.transferId = transferId;
+    }
+}

--- a/share_app/src/main/java/org/odk/share/dto/TransferInstance.java
+++ b/share_app/src/main/java/org/odk/share/dto/TransferInstance.java
@@ -10,7 +10,7 @@ public class TransferInstance {
     public static final String INSTRUCTIONS = "instructions";
     public static final String INSTANCE_ID = "instanceId";
     public static final String TRANSFER_STATUS = "transferStatus";
-    public static final String RECEIVED_REVIEW = "receivedReview";
+    public static final String RECEIVED_REVIEW_STATUS = "receivedReviewStatus";
     public static final String LAST_STATUS_CHANGE_DATE = "lastStatusChangeDate";
     public static final String VISITED_COUNT = "visitedCount";
 
@@ -28,6 +28,15 @@ public class TransferInstance {
     private String transferStatus;
     private Long lastStatusChangeDate;
     private Instance instance;
+    private int receivedReviewStatus;
+
+    public int getReceivedReviewStatus() {
+        return receivedReviewStatus;
+    }
+
+    public void setReceivedReviewStatus(int receivedReviewStatus) {
+        this.receivedReviewStatus = receivedReviewStatus;
+    }
 
     public Instance getInstance() {
         return instance;

--- a/share_app/src/main/java/org/odk/share/dto/TransferInstance.java
+++ b/share_app/src/main/java/org/odk/share/dto/TransferInstance.java
@@ -10,6 +10,7 @@ public class TransferInstance {
     public static final String INSTRUCTIONS = "instructions";
     public static final String INSTANCE_ID = "instanceId";
     public static final String TRANSFER_STATUS = "transferStatus";
+    public static final String RECEIVED_REVIEW = "receivedReview";
     public static final String LAST_STATUS_CHANGE_DATE = "lastStatusChangeDate";
     public static final String VISITED_COUNT = "visitedCount";
 

--- a/share_app/src/main/java/org/odk/share/fragments/ReviewedInstancesFragment.java
+++ b/share_app/src/main/java/org/odk/share/fragments/ReviewedInstancesFragment.java
@@ -1,5 +1,6 @@
 package org.odk.share.fragments;
 
+import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
@@ -13,12 +14,14 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.odk.share.R;
+import org.odk.share.activities.SendActivity;
 import org.odk.share.adapters.TransferInstanceAdapter;
 import org.odk.share.dao.InstancesDao;
 import org.odk.share.dao.TransferDao;
 import org.odk.share.dto.Instance;
 import org.odk.share.dto.TransferInstance;
 import org.odk.share.provider.InstanceProviderAPI;
+import org.odk.share.utilities.ArrayUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,6 +32,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 
+import static org.odk.share.activities.InstancesList.INSTANCE_IDS;
 import static org.odk.share.activities.MainActivity.FORM_DISPLAY_NAME;
 import static org.odk.share.activities.MainActivity.FORM_ID;
 import static org.odk.share.activities.MainActivity.FORM_VERSION;
@@ -203,6 +207,17 @@ public class ReviewedInstancesFragment extends InstanceListFragment {
 
     @OnClick(R.id.bAction)
     public void sendForms() {
-
+        List<Long> instanceIds = new ArrayList<>();
+        for (TransferInstance transferInstance: transferInstanceList) {
+            if (selectedInstances.contains(transferInstance.getId())) {
+                instanceIds.add(transferInstance.getInstanceId());
+            }
+        }
+        Intent intent = new Intent(getContext(), SendActivity.class);
+        Long[] arr = instanceIds.toArray(new Long[instanceIds.size()]);
+        long[] a = ArrayUtils.toPrimitive(arr);
+        intent.putExtra(INSTANCE_IDS, a);
+        intent.putExtra("mode", 2);
+        startActivity(intent);
     }
 }

--- a/share_app/src/main/java/org/odk/share/fragments/ReviewedInstancesFragment.java
+++ b/share_app/src/main/java/org/odk/share/fragments/ReviewedInstancesFragment.java
@@ -21,6 +21,7 @@ import org.odk.share.dao.TransferDao;
 import org.odk.share.dto.Instance;
 import org.odk.share.dto.TransferInstance;
 import org.odk.share.provider.InstanceProviderAPI;
+import org.odk.share.utilities.ApplicationConstants;
 import org.odk.share.utilities.ArrayUtils;
 
 import java.util.ArrayList;
@@ -64,6 +65,7 @@ public class ReviewedInstancesFragment extends InstanceListFragment {
     TransferInstanceAdapter transferInstanceAdapter;
     List<TransferInstance> transferInstanceList;
     private static final String REVIEWED_INSTANCE_LIST_SORTING_ORDER = "reviewedInstanceListSortingOrder";
+    public static final String MODE = "mode";
 
 
     @Override
@@ -217,7 +219,7 @@ public class ReviewedInstancesFragment extends InstanceListFragment {
         Long[] arr = instanceIds.toArray(new Long[instanceIds.size()]);
         long[] a = ArrayUtils.toPrimitive(arr);
         intent.putExtra(INSTANCE_IDS, a);
-        intent.putExtra("mode", 2);
+        intent.putExtra(MODE, ApplicationConstants.SEND_REVIEW_MODE);
         startActivity(intent);
     }
 }

--- a/share_app/src/main/java/org/odk/share/fragments/SentInstancesFragment.java
+++ b/share_app/src/main/java/org/odk/share/fragments/SentInstancesFragment.java
@@ -8,7 +8,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.CheckBox;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -27,7 +26,6 @@ import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.OnClick;
 
 import static org.odk.share.activities.MainActivity.FORM_DISPLAY_NAME;
 import static org.odk.share.activities.MainActivity.FORM_ID;
@@ -71,6 +69,8 @@ public class SentInstancesFragment extends InstanceListFragment {
         instanceMap = new HashMap<>();
         transferInstanceList = new ArrayList<>();
         selectedInstances = new LinkedHashSet<>();
+
+        buttonLayout.setVisibility(View.GONE);
 
         LinearLayoutManager llm = new LinearLayoutManager(getActivity());
         llm.setOrientation(LinearLayoutManager.VERTICAL);
@@ -147,7 +147,7 @@ public class SentInstancesFragment extends InstanceListFragment {
     }
 
     private void setupAdapter() {
-        transferInstanceAdapter = new TransferInstanceAdapter(getActivity(), transferInstanceList, this::onItemClick, selectedInstances, true);
+        transferInstanceAdapter = new TransferInstanceAdapter(getActivity(), transferInstanceList, this::onItemClick, selectedInstances, false);
         recyclerView.setAdapter(transferInstanceAdapter);
     }
 
@@ -163,44 +163,5 @@ public class SentInstancesFragment extends InstanceListFragment {
     }
 
     private void onItemClick(View view, int position) {
-        CheckBox checkBox = view.findViewById(R.id.checkbox);
-        checkBox.setChecked(!checkBox.isChecked());
-
-        TransferInstance transferInstance = transferInstanceList.get(position);
-        Long id = transferInstance.getId();
-
-        if (selectedInstances.contains(id)) {
-            selectedInstances.remove(id);
-        } else {
-            selectedInstances.add(id);
-        }
-        toggleButtonLabel();
-    }
-
-    @OnClick(R.id.bToggle)
-    public void toggle() {
-        boolean newState = transferInstanceAdapter.getItemCount() > selectedInstances.size();
-
-        if (newState) {
-            for (TransferInstance instance: transferInstanceList) {
-                selectedInstances.add(instance.getId());
-            }
-        } else {
-            selectedInstances.clear();
-        }
-
-        transferInstanceAdapter.notifyDataSetChanged();
-        toggleButtonLabel();
-    }
-
-    private void toggleButtonLabel() {
-        toggleButton.setText(selectedInstances.size() == transferInstanceAdapter.getItemCount() ?
-                getString(R.string.clear_all) : getString(R.string.select_all));
-        sendButton.setEnabled(selectedInstances.size() > 0);
-    }
-
-    @OnClick(R.id.bAction)
-    public void sendForms() {
-
     }
 }

--- a/share_app/src/main/java/org/odk/share/provider/InstanceMapProvider.java
+++ b/share_app/src/main/java/org/odk/share/provider/InstanceMapProvider.java
@@ -1,0 +1,192 @@
+package org.odk.share.provider;
+
+import android.content.ContentProvider;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.UriMatcher;
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteQueryBuilder;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+
+import org.odk.share.application.Share;
+import org.odk.share.database.ShareDatabaseHelper;
+import org.odk.share.dto.TransferInstance;
+
+import static org.odk.share.database.ShareDatabaseHelper.SHARE_INSTANCE_TABLE;
+
+/**
+ * Created by laksh on 8/2/2018.
+ */
+
+public class InstanceMapProvider extends ContentProvider {
+
+    private static final int INSTANCE_MAP = 1;
+    private static final int INSTANCE_MAP_ID = 2;
+
+    private static final String AUTHORITY = "org.odk.share.provider.odk.map";
+    public static final Uri CONTENT_URI = Uri.parse("content://" + AUTHORITY + "/instance");
+
+    private static final UriMatcher sUriMatcher;
+
+    private ShareDatabaseHelper databaseHelper;
+
+    private ShareDatabaseHelper getDbHelper() {
+
+        try {
+            Share.createODKDirs();
+        } catch (RuntimeException e) {
+            databaseHelper = null;
+            return null;
+        }
+
+        if (databaseHelper != null) {
+            return databaseHelper;
+        }
+        databaseHelper = new ShareDatabaseHelper(getContext());
+        return databaseHelper;
+    }
+
+    @Override
+    public boolean onCreate() {
+        ShareDatabaseHelper helper = getDbHelper();
+        return helper != null;
+    }
+
+    @Override
+    public Cursor query(@NonNull Uri uri, String[] projection, String selection,
+                        String[] selectionArgs, String sortOrder) {
+
+        SQLiteQueryBuilder qb = new SQLiteQueryBuilder();
+        qb.setTables(SHARE_INSTANCE_TABLE);
+
+        switch (sUriMatcher.match(uri)) {
+            case INSTANCE_MAP:
+                break;
+            case INSTANCE_MAP_ID:
+                qb.appendWhere(TransferInstance.ID + "="
+                        + uri.getLastPathSegment());
+                break;
+
+            default:
+                throw new IllegalArgumentException("Unknown URI " + uri);
+        }
+
+        Cursor c = null;
+        ShareDatabaseHelper shareDatabaseHelper = getDbHelper();
+        if (shareDatabaseHelper != null) {
+            c = qb.query(shareDatabaseHelper.getReadableDatabase(), projection, selection, selectionArgs, null, null, sortOrder);
+            c.setNotificationUri(getContext().getContentResolver(), uri);
+        }
+
+        return c;
+    }
+
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+
+    @Override
+    public synchronized Uri insert(@NonNull Uri uri, ContentValues initialValues) {
+        // Validate the requested uri
+        if (sUriMatcher.match(uri) != INSTANCE_MAP) {
+            throw new IllegalArgumentException("Unknown URI " + uri);
+        }
+
+        ShareDatabaseHelper shareDatabaseHelper = getDbHelper();
+        if (shareDatabaseHelper != null) {
+            ContentValues values;
+            if (initialValues != null) {
+                values = new ContentValues(initialValues);
+            } else {
+                values = new ContentValues();
+            }
+
+            long rowId = shareDatabaseHelper.getWritableDatabase().insert(SHARE_INSTANCE_TABLE, null, values);
+            if (rowId > 0) {
+                Uri instanceUri = ContentUris.withAppendedId(CONTENT_URI, rowId);
+                getContext().getContentResolver().notifyChange(instanceUri, null);
+                return instanceUri;
+            }
+        }
+
+        throw new SQLException("Failed to insert row into " + uri);
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, String where, String[] whereArgs) {
+        int count = 0;
+        ShareDatabaseHelper shareDatabaseHelper = getDbHelper();
+        if (shareDatabaseHelper != null) {
+            SQLiteDatabase db = shareDatabaseHelper.getWritableDatabase();
+
+            switch (sUriMatcher.match(uri)) {
+                case INSTANCE_MAP:
+                    count = db.delete(SHARE_INSTANCE_TABLE, where, whereArgs);
+                    break;
+
+                case INSTANCE_MAP_ID:
+                    String formId = uri.getLastPathSegment();
+                    count = db.delete(
+                            SHARE_INSTANCE_TABLE,
+                            TransferInstance.ID
+                                    + "="
+                                    + formId
+                                    + (!TextUtils.isEmpty(where) ? " AND (" + where
+                                    + ')' : ""), whereArgs);
+                    break;
+
+                default:
+                    throw new IllegalArgumentException("Unknown URI " + uri);
+            }
+
+            getContext().getContentResolver().notifyChange(uri, null);
+        }
+
+        return count;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String where,
+                      String[] whereArgs) {
+        int count = 0;
+        ShareDatabaseHelper shareDatabaseHelper = getDbHelper();
+        if (shareDatabaseHelper != null) {
+            SQLiteDatabase db = shareDatabaseHelper.getWritableDatabase();
+            switch (sUriMatcher.match(uri)) {
+                case INSTANCE_MAP:
+                    count = db.update(SHARE_INSTANCE_TABLE, values, where, whereArgs);
+                    break;
+
+                case INSTANCE_MAP_ID:
+                    String formId = uri.getLastPathSegment();
+                    count = db.update(
+                            SHARE_INSTANCE_TABLE,
+                            values,
+                            TransferInstance.ID
+                                    + "="
+                                    + formId
+                                    + (!TextUtils.isEmpty(where) ? " AND ("
+                                    + where + ')' : ""), whereArgs);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown URI " + uri);
+            }
+
+            getContext().getContentResolver().notifyChange(uri, null);
+        }
+
+        return count;
+    }
+
+    static {
+        sUriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
+        sUriMatcher.addURI(AUTHORITY, "instance", INSTANCE_MAP);
+        sUriMatcher.addURI(AUTHORITY, "instance/#", INSTANCE_MAP_ID);
+    }
+
+}

--- a/share_app/src/main/java/org/odk/share/services/SenderService.java
+++ b/share_app/src/main/java/org/odk/share/services/SenderService.java
@@ -59,10 +59,11 @@ public class SenderService {
 
     }
 
-    public void startUploading(long[] instancesToSend, int port) {
+    public void startUploading(long[] instancesToSend, int port, int mode) {
         PersistableBundleCompat extras = new PersistableBundleCompat();
         extras.putLongArray(UploadJob.INSTANCES, instancesToSend);
         extras.putInt(UploadJob.PORT, port);
+        extras.putInt("mode", mode);
 
         // Build request
         JobRequest request = new JobRequest.Builder(UploadJob.TAG)

--- a/share_app/src/main/java/org/odk/share/tasks/DownloadJob.java
+++ b/share_app/src/main/java/org/odk/share/tasks/DownloadJob.java
@@ -19,6 +19,7 @@ import org.odk.share.rx.RxEventBus;
 import org.odk.share.dao.InstancesDao;
 import org.odk.share.database.ShareDatabaseHelper;
 import org.odk.share.provider.InstanceProviderAPI;
+import org.odk.share.utilities.ApplicationConstants;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
@@ -249,7 +250,7 @@ public class DownloadJob extends Job {
                 Timber.d("Received uuid %s mode %s displayname %s submissionUri %s", uuid, mode, displayName, submissionUri);
                 long id = new InstanceMapDao().getInstanceId(uuid);
 
-                if (mode == 2) {
+                if (mode == ApplicationConstants.SEND_REVIEW_MODE) {
                     try (Cursor cursor = new TransferDao().getSentInstanceInstanceCursorUsingId(id)) {
                         if (id != -1 && cursor != null && cursor.getCount() > 0) {
                             // sent for review start receiving
@@ -269,7 +270,7 @@ public class DownloadJob extends Job {
                 int feedbackStatus = 0;
                 String feedback = null;
 
-                if (mode == 2) {
+                if (mode == ApplicationConstants.SEND_REVIEW_MODE) {
                     feedbackStatus = dis.readInt();
                     feedback = dis.readUTF();
                     if (feedback.equals("-1")) {
@@ -324,14 +325,13 @@ public class DownloadJob extends Job {
                     String[] selectionArgs = {String.valueOf(id)};
                     new InstancesDao().updateInstance(values, selection, selectionArgs);
                     TransferInstance transferInstance = new TransferDao().getSentTransferInstanceFromInstanceId(id);
-                    if (mode == 2) {
+                    if (mode == ApplicationConstants.SEND_REVIEW_MODE) {
                         ContentValues shareValues = new ContentValues();
                         shareValues.put(INSTRUCTIONS, feedback);
                         shareValues.put(RECEIVED_REVIEW_STATUS, feedbackStatus);
                         selection = TransferInstance.ID + " =?";
                         selectionArgs = new String[]{String.valueOf(transferInstance.getId())};
                         new TransferDao().updateInstance(shareValues, selection, selectionArgs);
-                        Timber.d("Mode 2 : " + "Exists");
                         sbResult.append(displayName + getContext().getString(R.string.success, getContext().getString(R.string.review_received)));
                     } else {
 

--- a/share_app/src/main/java/org/odk/share/tasks/UploadJob.java
+++ b/share_app/src/main/java/org/odk/share/tasks/UploadJob.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 
 import com.evernote.android.job.Job;
 
+import org.odk.share.R;
 import org.odk.share.application.Share;
 import org.odk.share.dao.FormsDao;
 import org.odk.share.dao.InstanceMapDao;
@@ -63,6 +64,8 @@ public class UploadJob extends Job {
     private int total;
     private int mode;
 
+    private StringBuilder sbResult;
+
     @NonNull
     @Override
     protected Result onRunJob(@NonNull Params params) {
@@ -79,6 +82,7 @@ public class UploadJob extends Job {
         instancesToSend = ArrayUtils.toObject(params.getExtras().getLongArray(INSTANCES));
         port = params.getExtras().getInt(PORT, -1);
         mode = params.getExtras().getInt("mode", 1);
+        sbResult = new StringBuilder();
     }
 
     private UploadEvent uploadInstances() {
@@ -104,7 +108,7 @@ public class UploadJob extends Job {
             return new UploadEvent(UploadEvent.Status.ERROR, e.getMessage());
         }
 
-        return new UploadEvent(UploadEvent.Status.FINISHED, String.valueOf(progress));
+        return new UploadEvent(UploadEvent.Status.FINISHED, sbResult.toString());
     }
 
     @Override
@@ -219,11 +223,11 @@ public class UploadJob extends Job {
             }
 
             boolean formExistAtReceiver = dis.readBoolean();
-            Timber.d("Form exists " + formExistAtReceiver);
+            Timber.d("Form exists %b ", formExistAtReceiver);
 
             if (!formExistAtReceiver) {
                 sendForm(formId, formVersion);
-                Timber.d("Form Sent");
+                Timber.d("Form sent to the receiver");
             }
 
             Timber.d("Sending Instances");
@@ -288,6 +292,14 @@ public class UploadJob extends Job {
                     } else {
                         dos.writeInt(0);
                     }
+
+                    sbResult.append(displayName + " ");
+                    if (formVersion != null) {
+                        sbResult.append(getContext().getString(R.string.version, formVersion)).append(" ");
+                    }
+                    sbResult.append(getContext().getString(R.string.id, formId) + " " +
+                            getContext().getString(R.string.success, getContext().getString(R.string.blank_form,
+                                    getContext().getString(R.string.sent))));
                 } catch (IOException e) {
                     Timber.e(e);
                 }
@@ -312,13 +324,12 @@ public class UploadJob extends Job {
         try {
             c = new InstancesDao().getInstancesCursor(selection, selectionArgs);
             HashMap<Long, String> instanceMap = new InstanceMapDao().getInstanceMap();
-            Timber.d("Map ", instanceMap);
             if (c != null && c.getCount() > 0) {
                 dos.writeInt(c.getCount());
                 c.moveToPosition(-1);
                 while (c.moveToNext()) {
+                    rxEventBus.post(new UploadEvent(UploadEvent.Status.UPLOADING, ++progress, total));
                     long id = c.getLong(c.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID));
-                    Timber.d("ID .. "+ id);
                     if (!instanceMap.containsKey(id)) {
                         String uuid = UUID.randomUUID().toString();
                         ContentValues values = new ContentValues();
@@ -327,8 +338,10 @@ public class UploadJob extends Job {
                         new ShareDatabaseHelper(getContext()).insertMapping(values);
                         instanceMap.put(id, uuid);
                     }
-                    Timber.d("Sent " + instanceMap.get(id));
                     dos.writeUTF(instanceMap.get(id));
+                    dos.writeInt(mode);
+                    Timber.d("Sent uuid %s and mode %s", instanceMap.get(id), mode);
+
                     String displayName = c.getString(
                             c.getColumnIndex(InstanceProviderAPI.InstanceColumns.DISPLAY_NAME));
                     String submissionUri = c.getString(
@@ -342,30 +355,63 @@ public class UploadJob extends Job {
                         dos.writeUTF(submissionUri);
                     }
 
-                    // mode tells whether its the review process or send process
-                    dos.writeInt(mode);
                     if (mode == 2) {
-                        TransferInstance transferInstance = new TransferDao().getReceivedTransferInstanceFromInstanceId(id);
-                        dos.writeInt(transferInstance.getReviewed());
-                        if (transferInstance.getInstructions() != null && transferInstance.getInstructions().length() > 0) {
-                            dos.writeUTF(transferInstance.getInstructions());
+                        Timber.d("Waiting for response from the receiver for %s %s ", id, mode);
+                        while (dis.available() <= 0) {
+                            continue;
+                        }
+
+                        boolean isFormSentForReview = dis.readBoolean();
+                        Timber.d("isFormSentForReview " + isFormSentForReview);
+                        if (!isFormSentForReview) {
+                            sbResult.append(displayName + getContext().getString(R.string.failed,
+                                    getContext().getString(R.string.review_not_asked)));
+                            continue;
                         } else {
-                            dos.writeUTF("-1");
+                            TransferInstance transferInstance = new TransferDao().getReceivedTransferInstanceFromInstanceId(id);
+                            dos.writeInt(transferInstance.getReviewed());
+                            if (transferInstance.getInstructions() != null && transferInstance.getInstructions().length() > 0) {
+                                dos.writeUTF(transferInstance.getInstructions());
+                            } else {
+                                dos.writeUTF("-1");
+                            }
+                            Timber.d("Sending instructions %s", transferInstance.getInstructions());
                         }
                     }
 
-                    rxEventBus.post(new UploadEvent(UploadEvent.Status.UPLOADING, ++progress, total));
+                    // mode tells whether its the review process or send process
                     String instance = c.getString(
                             c.getColumnIndex(InstanceProviderAPI.InstanceColumns.INSTANCE_FILE_PATH));
 
                     sendInstance(instance);
 
-                    // add row in share table
-                    ContentValues values = new ContentValues();
-                    values.put(INSTANCE_ID,
-                            c.getLong(c.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID)));
-                    values.put(TRANSFER_STATUS, STATUS_FORM_SENT);
-                    new ShareDatabaseHelper(getContext()).insertInstance(values);
+                    if (mode == 2) {
+                        // sent the review with the updated files
+                        sbResult.append(displayName + getContext().getString(R.string.success,
+                                getContext().getString(R.string.review_sent)));
+                    } else {
+                        // sent for review and update in transfer.db
+                        // check if it already exists at receiver end or not
+                        Timber.d("Waiting for receiver to send if it already exists or not");
+                        while (dis.available() <= 0) {
+                            continue;
+                        }
+
+                        boolean isFormAlreadySentForReview = dis.readBoolean();
+                        Timber.d("isFormAlreadySentForReview " + isFormAlreadySentForReview);
+                        if (isFormAlreadySentForReview) {
+                            sbResult.append(displayName + getContext().getString(R.string.success,
+                                    getContext().getString(R.string.sent_again)));
+                        } else {
+                            ContentValues values = new ContentValues();
+                            values.put(INSTANCE_ID,
+                                    c.getLong(c.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID)));
+                            values.put(TRANSFER_STATUS, STATUS_FORM_SENT);
+                            new ShareDatabaseHelper(getContext()).insertInstance(values);
+                            sbResult.append(displayName + getContext().getString(R.string.success,
+                                    getContext().getString(R.string.sent_for_review)));
+                        }
+                    }
                 }
             }
         } catch (IOException e) {

--- a/share_app/src/main/java/org/odk/share/tasks/UploadJob.java
+++ b/share_app/src/main/java/org/odk/share/tasks/UploadJob.java
@@ -18,6 +18,7 @@ import org.odk.share.database.ShareDatabaseHelper;
 import org.odk.share.provider.FormsProviderAPI;
 import org.odk.share.provider.InstanceProviderAPI;
 import org.odk.share.rx.RxEventBus;
+import org.odk.share.utilities.ApplicationConstants;
 import org.odk.share.utilities.ArrayUtils;
 import org.odk.share.utilities.FileUtils;
 
@@ -44,6 +45,7 @@ import static org.odk.share.dto.InstanceMap.INSTANCE_UUID;
 import static org.odk.share.dto.TransferInstance.INSTANCE_ID;
 import static org.odk.share.dto.TransferInstance.STATUS_FORM_SENT;
 import static org.odk.share.dto.TransferInstance.TRANSFER_STATUS;
+import static org.odk.share.fragments.ReviewedInstancesFragment.MODE;
 
 public class UploadJob extends Job {
 
@@ -81,7 +83,7 @@ public class UploadJob extends Job {
     private void initJob(Params params) {
         instancesToSend = ArrayUtils.toObject(params.getExtras().getLongArray(INSTANCES));
         port = params.getExtras().getInt(PORT, -1);
-        mode = params.getExtras().getInt("mode", 1);
+        mode = params.getExtras().getInt(MODE, ApplicationConstants.ASK_REVIEW_MODE);
         sbResult = new StringBuilder();
     }
 
@@ -355,7 +357,7 @@ public class UploadJob extends Job {
                         dos.writeUTF(submissionUri);
                     }
 
-                    if (mode == 2) {
+                    if (mode == ApplicationConstants.SEND_REVIEW_MODE) {
                         Timber.d("Waiting for response from the receiver for %s %s ", id, mode);
                         while (dis.available() <= 0) {
                             continue;
@@ -385,7 +387,7 @@ public class UploadJob extends Job {
 
                     sendInstance(instance);
 
-                    if (mode == 2) {
+                    if (mode == ApplicationConstants.SEND_REVIEW_MODE) {
                         // sent the review with the updated files
                         sbResult.append(displayName + getContext().getString(R.string.success,
                                 getContext().getString(R.string.review_sent)));

--- a/share_app/src/main/java/org/odk/share/utilities/ApplicationConstants.java
+++ b/share_app/src/main/java/org/odk/share/utilities/ApplicationConstants.java
@@ -13,6 +13,8 @@ public class ApplicationConstants {
 
     // based on http://www.sqlite.org/limits.html
     public static final int SQLITE_MAX_VARIABLE_NUMBER = 999;
+    public static final int ASK_REVIEW_MODE = 1;
+    public static final int SEND_REVIEW_MODE = 2;
 
     public abstract static class SortingOrder {
         public static final int BY_NAME_ASC = 0;

--- a/share_app/src/main/res/values/strings.xml
+++ b/share_app/src/main/res/values/strings.xml
@@ -54,8 +54,6 @@
     <string name="sending_items">Sending %1$s of %2$s form(s)</string>
     <string name="receiving_items">Receiving %1$s of %2$s form(s)</string>
     <string name="transfer_result">Transfer result</string>
-    <string name="receive_success">Successfully received %1$s form(s)</string>
-    <string name="send_success">Successfully sent %1$s form(s)</string>
     <string name="error_while_downloading">Error occurred while downloading form: %1$s</string>
     <string name="error_while_uploading">Error occurred while uploading form: %1$s</string>
     <string name="download_queued">Downloading queued…</string>
@@ -97,4 +95,21 @@
     <string name="received_on">Unreviewed, Received on %s</string>
     <string name="sent_on">Sent on %s</string>
     <string name="date_at_time">EEE, MMM dd, yyyy \'at\' HH:mm</string> <!-- http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
+
+    <string name="blank_form">(Blank form %s)</string>
+    <string name="success">-Success %s\n</string>
+    <string name="failed">-Failed %s\n</string>
+    <string name="review_not_asked">(Review not asked by the receiver)</string>
+    <string name="not_sent_for_review">(Form not sent for review)</string>
+    <string name="review_sent">(Review sent)</string>
+    <string name="review_received">(Review received)</string>
+    <string name="sent_for_review">(Sent for review)</string>
+    <string name="received_for_review">(Received for review)</string>
+    <string name="updated">(Updated)</string>
+    <string name="sent_again">(Sent again)</string>
+    <string name="form_received_by_reviewer">%s by reviewer</string>
+    <string name="accepted">Accepted</string>
+    <string name="rejected">Rejected</string>
+    <string name="feedback_sent">\nFeedback sent by reviewer: %s</string>
+    <string name="no_feedback_sent">\nNo feedback sent by the reviewer</string>
 </resources>


### PR DESCRIPTION
Closes #81 

- Feedback is only sent to the enumerator who asked for the review.
- Sent tabs updated (Now the buttons are removed only it shows information about the sent forms and the feedback/reviewStatus received by the receiver)
- Transfer result dialog contains result about individual blank form, filled form status.
- Sending same form again and again will not create seperate entries for every transfer, it will update the same existing form with the new files received.