### PR TITLE
4 prevent duplicating of submissions in destination

### DIFF
--- a/share_app/src/main/AndroidManifest.xml
+++ b/share_app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission
         android:name="android.permission.WRITE_SETTINGS"
         tools:ignore="ProtectedPermissions" />

--- a/share_app/src/main/java/org/odk/share/application/Share.java
+++ b/share_app/src/main/java/org/odk/share/application/Share.java
@@ -28,7 +28,7 @@ public class Share extends DaggerApplication {
         return singleton;
     }
 
-    public static final String ODK_ROOT = Environment.getExternalStorageDirectory() + File.separator + "share";
+    public static final String ODK_ROOT = Environment.getExternalStorageDirectory() + File.separator + "odk";
     public static final String ODK_COLLECT_ROOT = Environment.getExternalStorageDirectory() + File.separator + "odk";
     public static final String FORMS_PATH = ODK_COLLECT_ROOT + File.separator + "forms";
     public static final String INSTANCES_PATH = ODK_COLLECT_ROOT + File.separator + "instances";

--- a/share_app/src/main/java/org/odk/share/dao/TransferDao.java
+++ b/share_app/src/main/java/org/odk/share/dao/TransferDao.java
@@ -43,9 +43,9 @@ public class TransferDao {
         return getInstancesCursor(null, selection, selectionArgs, null);
     }
 
-    public Cursor getSentInstanceInstanceCursorUsingId(long id) {
-        String selection = TransferInstance.TRANSFER_STATUS + " =? AND " + TransferInstance.INSTANCE_ID + " =?";
-        String[] selectionArgs = {TransferInstance.STATUS_FORM_SENT, String.valueOf(id)};
+    public Cursor getSentInstanceInstanceCursorUsingUuid(String uuid) {
+        String selection = TransferInstance.TRANSFER_STATUS + " =? AND " + TransferInstance.INSTANCE_UUID + " =?";
+        String[] selectionArgs = {TransferInstance.STATUS_FORM_SENT, uuid};
         return getInstancesCursor(null, selection, selectionArgs, null);
     }
 
@@ -101,9 +101,9 @@ public class TransferDao {
         return null;
     }
 
-    public TransferInstance getSentTransferInstanceFromInstanceId(long instanceId) {
-        String selection = TransferInstance.INSTANCE_ID + " =? AND " + TransferInstance.TRANSFER_STATUS + " =?";
-        String[] selectionArgs = {String.valueOf(instanceId), TransferInstance.STATUS_FORM_SENT};
+    public TransferInstance getSentTransferInstanceFromInstanceUuid(String uuid) {
+        String selection = TransferInstance.INSTANCE_UUID + " =? AND " + TransferInstance.TRANSFER_STATUS + " =?";
+        String[] selectionArgs = {uuid, TransferInstance.STATUS_FORM_SENT};
         Cursor cursor = getInstancesCursor(null, selection, selectionArgs, null);
         List<TransferInstance> transferInstanceList = getInstancesFromCursor(cursor);
         if (transferInstanceList.size() > 0) {
@@ -121,6 +121,7 @@ public class TransferDao {
                     int isReviewedColumnIndex = cursor.getColumnIndex(TransferInstance.REVIEW_STATUS);
                     int instructionColumnIndex = cursor.getColumnIndex(TransferInstance.INSTRUCTIONS);
                     int instanceIdColumnIndex = cursor.getColumnIndex(TransferInstance.INSTANCE_ID);
+                    int instanceUuidColumnIndex = cursor.getColumnIndex(TransferInstance.INSTANCE_UUID);
                     int transferStatusColumnIndex = cursor.getColumnIndex(TransferInstance.TRANSFER_STATUS);
                     int lastStatusChangeDateColumnIndex = cursor.getColumnIndex(TransferInstance.LAST_STATUS_CHANGE_DATE);
                     int receivedReviewStatusColumnIndex = cursor.getColumnIndex(TransferInstance.RECEIVED_REVIEW_STATUS);
@@ -130,6 +131,7 @@ public class TransferDao {
                     transferInstance.setReviewed(cursor.getInt(isReviewedColumnIndex));
                     transferInstance.setInstructions(cursor.getString(instructionColumnIndex));
                     transferInstance.setInstanceId(cursor.getLong(instanceIdColumnIndex));
+                    transferInstance.setInstanceUuid(cursor.getString(instanceUuidColumnIndex));
                     transferInstance.setTransferStatus(cursor.getString(transferStatusColumnIndex));
                     transferInstance.setLastStatusChangeDate(cursor.getLong(lastStatusChangeDateColumnIndex));
                     transferInstance.setReceivedReviewStatus(cursor.getInt(receivedReviewStatusColumnIndex));

--- a/share_app/src/main/java/org/odk/share/database/ShareDatabaseHelper.java
+++ b/share_app/src/main/java/org/odk/share/database/ShareDatabaseHelper.java
@@ -6,6 +6,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
 import org.odk.share.application.Share;
+import org.odk.share.dto.TransferInstance;
 
 import timber.log.Timber;
 
@@ -55,6 +56,7 @@ public class ShareDatabaseHelper extends SQLiteOpenHelper {
                 + REVIEW_STATUS + " integer, "
                 + INSTRUCTIONS + " text, "
                 + INSTANCE_ID + " integer not null, "
+                + TransferInstance.INSTANCE_UUID + " text not null, "
                 + TRANSFER_STATUS + " text not null, "
                 + RECEIVED_REVIEW_STATUS + " integer,"
                 + VISITED_COUNT + " integer, "

--- a/share_app/src/main/java/org/odk/share/dto/TransferInstance.java
+++ b/share_app/src/main/java/org/odk/share/dto/TransferInstance.java
@@ -9,6 +9,7 @@ public class TransferInstance {
     public static final String REVIEW_STATUS = "reviewStatus";
     public static final String INSTRUCTIONS = "instructions";
     public static final String INSTANCE_ID = "instanceId";
+    public static final String INSTANCE_UUID = "instanceUuid";
     public static final String TRANSFER_STATUS = "transferStatus";
     public static final String RECEIVED_REVIEW_STATUS = "receivedReviewStatus";
     public static final String LAST_STATUS_CHANGE_DATE = "lastStatusChangeDate";
@@ -25,6 +26,7 @@ public class TransferInstance {
     private int isReviewed;
     private String instructions;
     private Long instanceId;
+    private String instanceUuid;
     private String transferStatus;
     private Long lastStatusChangeDate;
     private Instance instance;
@@ -74,8 +76,16 @@ public class TransferInstance {
         return instanceId;
     }
 
+    public String getInstanceUuid() {
+        return instanceUuid;
+    }
+
     public void setInstanceId(Long instanceId) {
         this.instanceId = instanceId;
+    }
+
+    public void setInstanceUuid(String instanceUuid) {
+        this.instanceUuid = instanceUuid;
     }
 
     public String getTransferStatus() {

--- a/share_app/src/main/java/org/odk/share/tasks/DownloadJob.java
+++ b/share_app/src/main/java/org/odk/share/tasks/DownloadJob.java
@@ -238,11 +238,11 @@ public class DownloadJob extends Job {
             }
 
             Timber.d(displayName + " " + formId + " " + formVersion + " " + submissionUri);
-            String formName = receiveFile(FORMS_PATH);
+            String formName = receiveFile(FORMS_PATH, false);
             int numOfRes = dis.readInt();
             String formMediaPath = FORMS_PATH + "/" + displayName + "-media";
             while (numOfRes-- > 0) {
-                receiveFile(formMediaPath);
+                receiveFile(formMediaPath, false);
             }
 
             // Add row in forms db
@@ -320,11 +320,11 @@ public class DownloadJob extends Job {
                 int numRes = dis.readInt();
                 String time = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss-SSS",
                         Locale.ENGLISH).format(Calendar.getInstance().getTime());
-                String path = INSTANCES_PATH + "/" + formId + "_" + time;
-                String instanceFilePath = receiveFile(path);
+                String path = INSTANCES_PATH + "/" + formId + "_" + uuid;
+                String instanceFilePath = receiveFile(path, true);
 
                 while (--numRes > 0) {
-                    receiveFile(path);
+                    receiveFile(path, false);
                 }
 
                 // Add row in instances table
@@ -382,7 +382,24 @@ public class DownloadJob extends Job {
         }
     }
 
-    private String receiveFile(String path) {
+    private boolean clearDirectory(String path) {
+        try {
+            File directory = new File(path);
+            if (directory.exists()) {
+                directory.delete();
+
+                return true;
+            }
+        } catch (Exception e) {
+            Timber.e(e);
+        }
+
+        return false;
+    }
+
+    private String receiveFile(String path, boolean clearPath) {
+        if (clearPath) clearDirectory(path);
+
         String filename = null;
         try {
             filename = dis.readUTF();

--- a/share_app/src/main/java/org/odk/share/tasks/DownloadJob.java
+++ b/share_app/src/main/java/org/odk/share/tasks/DownloadJob.java
@@ -287,8 +287,8 @@ public class DownloadJob extends Job {
                 long id = new InstanceMapDao().getInstanceId(uuid);
 
                 if (mode == ApplicationConstants.SEND_REVIEW_MODE) {
-                    try (Cursor cursor = new TransferDao().getSentInstanceInstanceCursorUsingId(id)) {
-                        if (id != -1 && cursor != null && cursor.getCount() > 0) {
+                    try (Cursor cursor = new TransferDao().getSentInstanceInstanceCursorUsingUuid(uuid)) {
+                        if (cursor != null && cursor.getCount() > 0) {
                             // sent for review start receiving
                             Timber.d("Form sent for review");
                             dos.writeBoolean(true);
@@ -352,6 +352,7 @@ public class DownloadJob extends Job {
                     // Add row in share table
                     ContentValues shareValues = new ContentValues();
                     shareValues.put(INSTANCE_ID, Long.parseLong(uri.getLastPathSegment()));
+                    shareValues.put(TransferInstance.INSTANCE_UUID, uuid);
                     shareValues.put(TRANSFER_STATUS, STATUS_FORM_RECEIVE);
                     sbResult.append(displayName + getContext().getString(R.string.success,
                             getContext().getString(R.string.received_for_review)));
@@ -360,7 +361,7 @@ public class DownloadJob extends Job {
                     String selection = InstanceProviderAPI.InstanceColumns._ID + "=?";
                     String[] selectionArgs = {String.valueOf(id)};
                     new InstancesDao().updateInstance(values, selection, selectionArgs);
-                    TransferInstance transferInstance = new TransferDao().getSentTransferInstanceFromInstanceId(id);
+                    TransferInstance transferInstance = new TransferDao().getSentTransferInstanceFromInstanceUuid(uuid);
                     if (mode == ApplicationConstants.SEND_REVIEW_MODE) {
                         ContentValues shareValues = new ContentValues();
                         shareValues.put(INSTRUCTIONS, feedback);

--- a/share_app/src/main/java/org/odk/share/tasks/UploadJob.java
+++ b/share_app/src/main/java/org/odk/share/tasks/UploadJob.java
@@ -21,6 +21,7 @@ import org.odk.share.rx.RxEventBus;
 import org.odk.share.utilities.ApplicationConstants;
 import org.odk.share.utilities.ArrayUtils;
 import org.odk.share.utilities.FileUtils;
+import org.odk.share.utilities.OdkInstanceUtils;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
@@ -31,6 +32,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -362,24 +364,22 @@ public class UploadJob extends Job {
         Cursor c = null;
         try {
             c = new InstancesDao().getInstancesCursor(selection, selectionArgs);
-            HashMap<Long, String> instanceMap = new InstanceMapDao().getInstanceMap();
             if (c != null && c.getCount() > 0) {
                 dos.writeInt(c.getCount());
                 c.moveToPosition(-1);
                 while (c.moveToNext()) {
                     rxEventBus.post(new UploadEvent(UploadEvent.Status.UPLOADING, ++progress, total));
                     long id = c.getLong(c.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID));
-                    if (!instanceMap.containsKey(id)) {
-                        String uuid = UUID.randomUUID().toString();
-                        ContentValues values = new ContentValues();
-                        values.put(INSTANCE_ID, id);
-                        values.put(INSTANCE_UUID, uuid);
-                        new ShareDatabaseHelper(getContext()).insertMapping(values);
-                        instanceMap.put(id, uuid);
-                    }
-                    dos.writeUTF(instanceMap.get(id));
+                    String instancePath = c.getString(c.getColumnIndex(InstanceProviderAPI.InstanceColumns.INSTANCE_FILE_PATH));
+                    String uuid = OdkInstanceUtils.getInstanceUuid(instancePath);
+                    ContentValues cv = new ContentValues();
+                    cv.put(INSTANCE_ID, id);
+                    cv.put(INSTANCE_UUID, uuid);
+                    new ShareDatabaseHelper(getContext()).insertMapping(cv);
+
+                    dos.writeUTF(uuid);
                     dos.writeInt(mode);
-                    Timber.d("Sent uuid %s and mode %s", instanceMap.get(id), mode);
+                    Timber.d("Sent uuid %s and mode %s", uuid, mode);
 
                     String displayName = c.getString(
                             c.getColumnIndex(InstanceProviderAPI.InstanceColumns.DISPLAY_NAME));
@@ -445,6 +445,7 @@ public class UploadJob extends Job {
                             ContentValues values = new ContentValues();
                             values.put(INSTANCE_ID,
                                     c.getLong(c.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID)));
+                            values.put(TransferInstance.INSTANCE_UUID, uuid);
                             values.put(TRANSFER_STATUS, STATUS_FORM_SENT);
                             new ShareDatabaseHelper(getContext()).insertInstance(values);
                             sbResult.append(displayName + getContext().getString(R.string.success,
@@ -454,6 +455,8 @@ public class UploadJob extends Job {
                 }
             }
         } catch (IOException e) {
+            c.close();
+        } catch (NoSuchAlgorithmException e) {
             c.close();
         } finally {
             if (c != null) {

--- a/share_app/src/main/java/org/odk/share/utilities/OdkInstanceUtils.java
+++ b/share_app/src/main/java/org/odk/share/utilities/OdkInstanceUtils.java
@@ -1,0 +1,48 @@
+package org.odk.share.utilities;
+
+import org.odk.share.application.Share;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class OdkInstanceUtils {
+    /**
+     * Uniquely identifiable ID for an instance would be a combination of the name of the directory
+     * for the instance and the device id.
+     * @return
+     */
+    public static String getInstanceUuid(String instancePath) throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        return SHA1(getDeviceId() + instancePath);
+    }
+
+    private static String convertToHex(byte[] data) {
+        StringBuilder buf = new StringBuilder();
+        for (byte b : data) {
+            int halfbyte = (b >>> 4) & 0x0F;
+            int two_halfs = 0;
+            do {
+                buf.append((0 <= halfbyte) && (halfbyte <= 9) ? (char) ('0' + halfbyte) : (char) ('a' + (halfbyte - 10)));
+                halfbyte = b & 0x0F;
+            } while (two_halfs++ < 1);
+        }
+        return buf.toString();
+    }
+
+    private static String SHA1(String text) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        byte[] textBytes = text.getBytes("iso-8859-1");
+        md.update(textBytes, 0, textBytes.length);
+        byte[] sha1hash = md.digest();
+        return convertToHex(sha1hash);
+    }
+
+    /**
+     * Same logic used within ODK Collect to obtain the device id in a form
+     * @return
+     */
+    private static String getDeviceId() {
+        PropertyManager propertyManager = new PropertyManager(Share.getInstance());
+        return propertyManager.getSingularProperty(PropertyManager.DEVICE_ID_PROPERTY);
+    }
+}

--- a/share_app/src/main/java/org/odk/share/utilities/PropertyManager.java
+++ b/share_app/src/main/java/org/odk/share/utilities/PropertyManager.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2009 University of Washington
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.odk.share.utilities;
+
+import android.content.Context;
+import android.net.wifi.WifiInfo;
+import android.net.wifi.WifiManager;
+import android.provider.Settings;
+import android.telephony.TelephonyManager;
+import android.util.Log;
+
+import java.util.HashMap;
+import java.util.Locale;
+
+/**
+ * Used to return JavaRosa type device properties
+ *
+ * @author Yaw Anokwa (yanokwa@gmail.com)
+ * @author Jason Rogena (jrogena@ona.io)
+ */
+
+public class PropertyManager {
+
+    public static final String ANDROID6_FAKE_MAC = "02:00:00:00:00:00";
+
+    private String t = "PropertyManager";
+
+
+    private HashMap<String, String> mProperties;
+
+    public final static String DEVICE_ID_PROPERTY = "deviceid"; // imei
+    public final static String SUBSCRIBER_ID_PROPERTY = "subscriberid"; // imsi
+    public final static String SIM_SERIAL_PROPERTY = "simserial";
+    public final static String PHONE_NUMBER_PROPERTY = "phonenumber";
+
+    public PropertyManager(Context context) {
+        TelephonyManager mTelephonyManager;
+        Log.i(t, "calling constructor");
+
+        Context mContext = context;
+
+        mProperties = new HashMap<>();
+        mTelephonyManager = (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+
+        String deviceId = mTelephonyManager.getDeviceId();
+        if (deviceId != null && (deviceId.contains("*") || deviceId.contains("000000000000000"))) {
+            deviceId =
+                    Settings.Secure
+                            .getString(mContext.getContentResolver(), Settings.Secure.ANDROID_ID);
+
+        }
+
+        if (deviceId == null) {
+            // no SIM -- WiFi only
+            // Retrieve WiFiManager
+            WifiManager wifi = (WifiManager) mContext.getSystemService(Context.WIFI_SERVICE);
+
+            // Get WiFi status
+            WifiInfo info = wifi.getConnectionInfo();
+            if (info != null && !ANDROID6_FAKE_MAC.equals(info.getMacAddress())) {
+                deviceId = info.getMacAddress();
+            }
+        }
+
+        // if it is still null, use ANDROID_ID
+        if (deviceId == null) {
+            deviceId =
+                    Settings.Secure
+                            .getString(mContext.getContentResolver(), Settings.Secure.ANDROID_ID);
+        }
+
+        mProperties.put(DEVICE_ID_PROPERTY, deviceId);
+
+        String value;
+
+        value = mTelephonyManager.getSubscriberId();
+        if (value != null) {
+            mProperties.put(SUBSCRIBER_ID_PROPERTY, value);
+        }
+        value = mTelephonyManager.getSimSerialNumber();
+        if (value != null) {
+            mProperties.put(SIM_SERIAL_PROPERTY, value);
+        }
+        value = mTelephonyManager.getLine1Number();
+        if (value != null) {
+            mProperties.put(PHONE_NUMBER_PROPERTY, value);
+        }
+    }
+
+    public String getSingularProperty(String propertyName) {
+        // for now, all property names are in english...
+        return mProperties.get(propertyName.toLowerCase(Locale.ENGLISH));
+    }
+
+}


### PR DESCRIPTION
Use Instance UUID as the True Source Of Truth

Switch from using the instance ID to the instance UUID (that's now a SHA1 hash of the device ID + the instance directory, instead of a random number) as the true reference to a transfer, instead of using the instance ID.