### PR TITLE
Center the Connection Status TextView

### DIFF
--- a/share_app/src/main/res/layout/activity_send.xml
+++ b/share_app/src/main/res/layout/activity_send.xml
@@ -10,9 +10,9 @@
         android:id="@+id/tvConnectStatus"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/toolbar"
-        android:layout_margin="10dp"
         android:gravity="center"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
         android:text="@string/waiting_hotspot"
         android:textSize="20sp" />
 


### PR DESCRIPTION
### Fixes : #125

### Changes introduced:
* set center horizontal and vertical to true.
* remove the margin as it is no more required.

### GIF for the changes:

<img src="https://user-images.githubusercontent.com/36811908/53493928-69848300-3abe-11e9-98ab-520d69a879a0.gif" height="700" width="394">
